### PR TITLE
Change session message key from :error to :alert

### DIFF
--- a/routes/guests.rb
+++ b/routes/guests.rb
@@ -19,7 +19,7 @@ Guests = Syro.new(Frontend) {
         res.redirect "/"
       }
 
-      session[:error] = "Invalid login"
+      session[:alert] = "Invalid login"
 
       render("views/guests/login.mote")
     }
@@ -38,13 +38,13 @@ Guests = Syro.new(Frontend) {
       on(@invite.valid?) {
         Gatekeeper.invite(@invite.email)
 
-        session[:error] = "Check your email"
+        session[:alert] = "Check your email"
 
         res.redirect "/login"
       }
 
       on(true) {
-        session[:error] = "Invalid signup"
+        session[:alert] = "Invalid signup"
 
         render("views/guests/signup.mote", invite: @invite)
       }
@@ -69,7 +69,7 @@ Guests = Syro.new(Frontend) {
 
               authenticate(@user)
 
-              session[:error] = "Password updated"
+              session[:alert] = "Password updated"
 
               res.redirect "/"
             }
@@ -81,7 +81,7 @@ Guests = Syro.new(Frontend) {
           }
 
           on(true) {
-            session[:error] = "Invalid password"
+            session[:alert] = "Invalid password"
 
             render("views/guests/update.mote")
           }
@@ -89,7 +89,7 @@ Guests = Syro.new(Frontend) {
       }
 
       on(true) {
-        session[:error] = "Invalid or expired URL"
+        session[:alert] = "Invalid or expired URL"
 
         res.redirect "/reset"
       }
@@ -107,13 +107,13 @@ Guests = Syro.new(Frontend) {
       on(@user != nil) {
         Gatekeeper.reset(@user)
 
-        session[:error] = "Check your email"
+        session[:alert] = "Check your email"
 
         res.redirect "/login"
       }
 
       on(true) {
-        session[:error] = "Invalid email"
+        session[:alert] = "Invalid email"
 
         render("views/guests/reset.mote")
       }
@@ -133,13 +133,13 @@ Guests = Syro.new(Frontend) {
 
             authenticate(@user)
 
-            session[:error] = "Password updated"
+            session[:alert] = "Password updated"
 
             res.redirect "/"
           }
 
           on(true) {
-            session[:error] = "Invalid password"
+            session[:alert] = "Invalid password"
 
             render("views/guests/update.mote")
           }
@@ -147,7 +147,7 @@ Guests = Syro.new(Frontend) {
       }
 
       on(true) {
-        session[:error] = "Invalid or expired URL"
+        session[:alert] = "Invalid or expired URL"
 
         res.redirect "/reset"
       }

--- a/views/guests/login.mote
+++ b/views/guests/login.mote
@@ -5,9 +5,9 @@
 
 <h1>Login</h1>
 
-% if app.session[:error]
+% if app.session[:alert]
   <p>
-    {{ app.session.delete(:error) }}
+    {{ app.session.delete(:alert) }}
   </p>
 % end
 

--- a/views/guests/reset.mote
+++ b/views/guests/reset.mote
@@ -5,9 +5,9 @@
 
 <h1>Login</h1>
 
-% if app.session[:error]
+% if app.session[:alert]
   <p>
-    {{ app.session.delete(:error) }}
+    {{ app.session.delete(:alert) }}
   </p>
 % end
 

--- a/views/guests/signup.mote
+++ b/views/guests/signup.mote
@@ -5,9 +5,9 @@
 
 <h1>Signup</h1>
 
-% if app.session[:error]
+% if app.session[:alert]
   <p>
-    {{ app.session.delete(:error) }}
+    {{ app.session.delete(:alert) }}
   </p>
 % end
 

--- a/views/guests/update.mote
+++ b/views/guests/update.mote
@@ -5,9 +5,9 @@
 
 <h1>Update your password</h1>
 
-% if app.session[:error]
+% if app.session[:alert]
   <p>
-    {{ app.session.delete(:error) }}
+    {{ app.session.delete(:alert) }}
   </p>
 % end
 


### PR DESCRIPTION
There's only one message key being used in the routes and views,
to keep the demo very straightforward and simple.

It could be confusing for a newcomer to Syro, or even
Ruby to see something like:

``` ruby
session[:error] = "Password updated"
```

This uses the more generic term `alert`, which is used by many other
css and web frameworks to cover the cases of both success and error.
